### PR TITLE
No need to escape chkconfig service name in dict key.

### DIFF
--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -102,12 +102,12 @@ include 'components/altlogrotate/config';
 "/software/components/chkconfig/service" = {
   if (FETCH_CRL_VERSION >= '3.0') {
     # Run fetch-crl on boot
-    SELF[escape('fetch-crl-boot')] = dict("on", "",
+    SELF['fetch-crl-boot'] = dict("on", "",
                                           "startstop", true);
   };
 
   # Enable periodic fetch-crl (cron)
-  SELF[escape('fetch-crl-cron')] = dict("on", "",
+  SELF['fetch-crl-cron'] = dict("on", "",
                                         "startstop", true);
 
   SELF;


### PR DESCRIPTION
There is no need to escape the key of dict() in chkconfig. Moreover, it is for many other service not escaped. This create an issue when using unescape() function within quattor, as for instance **pbs_server** raises an error since **_se** is not a correct escape sequence.

This issue is globally due to the fact the unescape() function in pan raises an error when encountering wrong escape sequence, while the perl function doesn't (and is hence capable of treating both escaped & unescaped strings).